### PR TITLE
Fix kube-linter issues for multi-arch-controller pod/container

### DIFF
--- a/deploy/operator/deployment.yaml
+++ b/deploy/operator/deployment.yaml
@@ -33,4 +33,8 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "500m"
+          securityContext:
+            readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: multi-arch-controller


### PR DESCRIPTION
Set readOnlyRootFilesystem and runAsNonRoot to true.